### PR TITLE
Improve API error handling for weather search

### DIFF
--- a/weather-app/src/App.css
+++ b/weather-app/src/App.css
@@ -150,7 +150,8 @@ body {
 }
 
 .theme-toggle,
-.unit-toggle {
+.unit-toggle,
+.location-toggle {
   background: var(--dark-card);
   border: 1px solid var(--dark-border);
   border-radius: 50%;
@@ -168,7 +169,8 @@ body {
 }
 
 .app.light .theme-toggle,
-.app.light .unit-toggle {
+.app.light .unit-toggle,
+.app.light .location-toggle {
   background: var(--light-card);
   border: 1px solid var(--light-border);
   box-shadow: var(--light-shadow);
@@ -176,14 +178,26 @@ body {
 }
 
 .theme-toggle:hover,
-.unit-toggle:hover {
+.unit-toggle:hover,
+.location-toggle:hover {
   transform: scale(1.1);
   box-shadow: 0 8px 25px rgba(0, 0, 0, 0.4);
 }
 
 .app.light .theme-toggle:hover,
-.app.light .unit-toggle:hover {
+.app.light .unit-toggle:hover,
+.app.light .location-toggle:hover {
   box-shadow: 0 8px 25px rgba(0, 0, 0, 0.2);
+}
+
+.location-toggle:active {
+  background: var(--dark-progress);
+  color: white;
+}
+
+.app.light .location-toggle:active {
+  background: var(--light-progress);
+  color: white;
 }
 
 /* Contenido principal */
@@ -479,10 +493,16 @@ body {
 .city-card:hover {
   background: rgba(255, 255, 255, 0.1);
   transform: translateX(5px);
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.3);
 }
 
 .app.light .city-card:hover {
   background: rgba(0, 0, 0, 0.1);
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.2);
+}
+
+.city-card:active {
+  transform: translateX(5px) scale(0.98);
 }
 
 .city-info-left {

--- a/weather-app/src/App.jsx
+++ b/weather-app/src/App.jsx
@@ -24,7 +24,7 @@ function App() {
       setCity(cityName);
     } catch (err) {
       console.error('Error loading city:', err);
-      alert('City not found');
+      alert(err.message || 'City not found');
     }
   };
 
@@ -37,7 +37,7 @@ function App() {
       setSearchCity('');
     } catch (err) {
       console.error(err);
-      alert('City not found');
+      alert(err.message || 'City not found');
     }
   };
 

--- a/weather-app/src/App.jsx
+++ b/weather-app/src/App.jsx
@@ -104,7 +104,7 @@ function App() {
     if (!weatherData) {
       loadDefaultCity();
     }
-  }, []); // Solo se ejecuta una vez al montar el componente
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps -- Solo se ejecuta una vez al montar el componente
 
 
 

--- a/weather-app/src/context/WeatherContext.jsx
+++ b/weather-app/src/context/WeatherContext.jsx
@@ -4,7 +4,6 @@ import { createContext, useState } from 'react';
 export const WeatherContext = createContext();
 
 export const WeatherProvider = ({ children }) => {
-  const [lastCity, setLastCity] = useState('');
   const [weatherData, setWeatherData] = useState(null);
   const [hourlyForecast, setHourlyForecast] = useState([]);
   const [fiveDayForecast, setFiveDayForecast] = useState([]);
@@ -14,8 +13,8 @@ export const WeatherProvider = ({ children }) => {
       // Obtener clima actual
       const currentUrl = `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(city)}&appid=${import.meta.env.VITE_OPENWEATHER_KEY}&units=${units}`;
       const currentRes = await fetch(currentUrl);
-      if (!currentRes.ok) throw new Error('City not found');
       const currentData = await currentRes.json();
+      if (!currentRes.ok) throw new Error(currentData.message || 'Error fetching weather data');
       
       // Obtener pronóstico de 5 días
       const forecastUrl = `https://api.openweathermap.org/data/2.5/forecast?q=${encodeURIComponent(city)}&appid=${import.meta.env.VITE_OPENWEATHER_KEY}&units=${units}`;
@@ -48,7 +47,6 @@ export const WeatherProvider = ({ children }) => {
         setFiveDayForecast(daily);
       }
       
-      setLastCity(city);
       setWeatherData(currentData);
       return currentData;
     } catch (error) {
@@ -62,8 +60,8 @@ export const WeatherProvider = ({ children }) => {
       // Obtener clima actual por coordenadas
       const currentUrl = `https://api.openweathermap.org/data/2.5/weather?lat=${lat}&lon=${lon}&appid=${import.meta.env.VITE_OPENWEATHER_KEY}&units=${units}`;
       const currentRes = await fetch(currentUrl);
-      if (!currentRes.ok) throw new Error('Weather data not found');
       const currentData = await currentRes.json();
+      if (!currentRes.ok) throw new Error(currentData.message || 'Weather data not found');
       
       // Obtener pronóstico de 5 días por coordenadas
       const forecastUrl = `https://api.openweathermap.org/data/2.5/forecast?lat=${lat}&lon=${lon}&appid=${import.meta.env.VITE_OPENWEATHER_KEY}&units=${units}`;
@@ -96,7 +94,6 @@ export const WeatherProvider = ({ children }) => {
         setFiveDayForecast(daily);
       }
       
-      setLastCity('Mi ubicación');
       setWeatherData(currentData);
       return currentData;
     } catch (error) {

--- a/weather-app/src/context/WeatherContext.jsx
+++ b/weather-app/src/context/WeatherContext.jsx
@@ -57,6 +57,54 @@ export const WeatherProvider = ({ children }) => {
     }
   };
 
+  const fetchWeatherByCoords = async (lat, lon, units) => {
+    try {
+      // Obtener clima actual por coordenadas
+      const currentUrl = `https://api.openweathermap.org/data/2.5/weather?lat=${lat}&lon=${lon}&appid=${import.meta.env.VITE_OPENWEATHER_KEY}&units=${units}`;
+      const currentRes = await fetch(currentUrl);
+      if (!currentRes.ok) throw new Error('Weather data not found');
+      const currentData = await currentRes.json();
+      
+      // Obtener pronóstico de 5 días por coordenadas
+      const forecastUrl = `https://api.openweathermap.org/data/2.5/forecast?lat=${lat}&lon=${lon}&appid=${import.meta.env.VITE_OPENWEATHER_KEY}&units=${units}`;
+      const forecastRes = await fetch(forecastUrl);
+      if (forecastRes.ok) {
+        const forecastData = await forecastRes.json();
+        
+        // Procesar pronóstico por horas (próximas 24 horas)
+        const hourly = forecastData.list.slice(0, 8).map(item => ({
+          time: new Date(item.dt * 1000).toLocaleTimeString('en-US', { 
+            hour: 'numeric', 
+            minute: '2-digit',
+            hour12: true 
+          }),
+          condition: item.weather[0].main,
+          icon: getWeatherIcon(item.weather[0].main),
+          temp: Math.round(item.main.temp)
+        }));
+        
+        // Procesar pronóstico de 5 días
+        const daily = forecastData.list.filter((item, index) => index % 8 === 0).slice(0, 5).map((item, index) => ({
+          day: index === 0 ? 'Today' : new Date(item.dt * 1000).toLocaleDateString('en-US', { weekday: 'short' }),
+          condition: item.weather[0].main,
+          icon: getWeatherIcon(item.weather[0].main),
+          temp: Math.round(item.main.temp),
+          progress: Math.random() * 60 + 30 // Valor aleatorio para la barra de progreso
+        }));
+        
+        setHourlyForecast(hourly);
+        setFiveDayForecast(daily);
+      }
+      
+      setLastCity('Mi ubicación');
+      setWeatherData(currentData);
+      return currentData;
+    } catch (error) {
+      console.error('Error fetching weather data by coordinates:', error);
+      throw error;
+    }
+  };
+
   const getWeatherIcon = (condition) => {
     const iconMap = {
       'snow': '❄️',
@@ -76,6 +124,7 @@ export const WeatherProvider = ({ children }) => {
     <WeatherContext.Provider value={{ 
       weatherData, 
       fetchWeather, 
+      fetchWeatherByCoords,
       hourlyForecast, 
       fiveDayForecast
     }}>


### PR DESCRIPTION
## Summary
- show API error messages instead of generic 'City not found'
- clean up unused weather context state

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b59c10c0c483298be5196444455461